### PR TITLE
Speedup

### DIFF
--- a/CDriver.py
+++ b/CDriver.py
@@ -40,6 +40,7 @@ class CDriver():
         print('\tStart metric computation.')
 
         # computing the element-wise metric
+        limited = 0
         for element in meshDict[keyElem]:
 
             # compute element area
@@ -56,9 +57,12 @@ class CDriver():
             element.ComputePatchArea()
 
             # computing the element-wise metric
-            element.ComputeMetric(toll=self.params['toll'], 
-                                  diam=self.params['diam'], 
-                                  card=self.params['card'])
+            limited += element.ComputeMetric(toll=self.params['toll'], 
+                                            diam=self.params['diam'], 
+                                            card=self.params['card'])
+            
+        print('\t\tAspect ratio limited by gmin in %i out of %i elements' %
+              (limited, len(meshDict[keyElem])))
 
         # computing the vertex-wise metric
         for vertex in meshDict['Vertices']:

--- a/CElement.py
+++ b/CElement.py
@@ -177,6 +177,8 @@ class CElement():
         valG1 = max(np.real(eigenValRefG[0]), valGmin)
         valG2 = max(np.real(eigenValRefG[1]), valGmin)
 
+        limited = 1 if valG2 == valGmin or valG1 == valGmin else 0
+
         factor = (toll**2 / (2 * card * referencePatchArea))**0.5
 
         lambda_1 = factor * valG2**(-0.5)
@@ -186,6 +188,8 @@ class CElement():
         RkNewT = np.hstack((vecG2[:,np.newaxis], vecG1[:,np.newaxis]))
 
         self.metric = RkNewT @ lambdaNewm2 @ np.transpose(RkNewT)
+
+        return limited
 
 
 def ComputeError(elem, x, y, patchArea):


### PR DESCRIPTION
Speeding up the element-wise metric computation by discarding the patchAvgGradient() method.